### PR TITLE
0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix for possible race condition when **OpenMP** used
 * Remove `#define` construct to allow functions to better be used directly in
 if-statements
+* Start re-laying out nodes from removal location
 
 ### Version 0.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 0.7.6
+
+* Fix for possible race condition when **OpenMP** used
+* Remove `#define` construct to allow functions to better be used directly in
+if-statements
 
 ### Version 0.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## Current Version
+
 ### Version 0.7.6
 
 * Fix for possible race condition when **OpenMP** used
 * Remove `#define` construct to allow functions to better be used directly in
 if-statements
 * Start re-laying out nodes from removal location
+* Unique HashFunction type when using with related libraries
 
 ### Version 0.7.5
 

--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ None
 
 ### Future Enhancements:
 * Allow for sorting from the `hashmap_keys` function
-* Improve relaying out nodes to not have to loop over the whole hashmap
 * Prove if relaying out nodes needs to do more than 1 loop
+* Add ability to merge Hashmaps
+* Add additional utility functions
+  * float
+  * double
+* More in-depth test suite

--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ hashmap_destroy(&h);
 None
 
 ### Future Enhancements:
-To be determined
+* Allow for sorting from the `hashmap_keys` function
+* Improve relaying out nodes to not have to loop over the whole hashmap
+* Prove if relaying out nodes needs to do more than 1 loop

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -3,7 +3,7 @@
 ***	 Author: Tyler Barrus
 ***	 email:  barrust@gmail.com
 ***
-***	 Version: 0.7.5
+***	 Version: 0.7.6
 ***
 ***	 License: MIT 2015
 ***
@@ -30,7 +30,7 @@
 static uint64_t default_hash(char *key);
 static inline float __get_fullness(HashMap *h);
 static inline int __calc_big_o(uint64_t num_nodes, uint64_t i, uint64_t idx);
-static int   __allocate_hashmap(HashMap *h, uint64_t num_els, HashFunction hash_function);
+static int   __allocate_hashmap(HashMap *h, uint64_t num_els, HashmapHashFunction hash_function);
 static int   __relayout_nodes(HashMap *h, uint64_t loc);
 static void* __get_node(HashMap *h, char *key, uint64_t hash, uint64_t *i, int *error);
 static void  __assign_node(HashMap *h, char *key, void *value, short mallocd, uint64_t i, uint64_t hash);
@@ -46,7 +46,7 @@ int hashmap_init(HashMap *h) {
 	return hashmap_init_alt(h, NULL);
 }
 
-int hashmap_init_alt(HashMap *h, HashFunction hash_function) {
+int hashmap_init_alt(HashMap *h, HashmapHashFunction hash_function) {
 	return __allocate_hashmap(h, INITIAL_NUM_ELEMENTS, hash_function);
 }
 
@@ -186,7 +186,7 @@ static uint64_t default_hash(char *key) { // FNV-1a hash (http://www.isthe.com/c
 	return h;
 }
 
-static int  __allocate_hashmap(HashMap *h, uint64_t num_els, HashFunction hash_function) {
+static int  __allocate_hashmap(HashMap *h, uint64_t num_els, HashmapHashFunction hash_function) {
 	uint64_t i;
 	if (num_els == INITIAL_NUM_ELEMENTS) {
 		h->nodes = (hashmap_node**) malloc(num_els * sizeof(hashmap_node*));
@@ -216,9 +216,6 @@ static int  __allocate_hashmap(HashMap *h, uint64_t num_els, HashFunction hash_f
 }
 
 static int __relayout_nodes(HashMap *h, uint64_t loc) {
-	if (loc > h->number_nodes) {
-		loc = 0;
-	}
 	int moved_one = 1;
 	uint64_t i;
 	for (i = loc; i < h->number_nodes; i++) {

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -31,7 +31,7 @@ static uint64_t default_hash(char *key);
 static inline float __get_fullness(HashMap *h);
 static inline int __calc_big_o(uint64_t num_nodes, uint64_t i, uint64_t idx);
 static int   __allocate_hashmap(HashMap *h, uint64_t num_els, HashFunction hash_function);
-static int   __relayout_nodes(HashMap *h);
+static int   __relayout_nodes(HashMap *h, uint64_t loc);
 static void* __get_node(HashMap *h, char *key, uint64_t hash, uint64_t *i, int *error);
 static void  __assign_node(HashMap *h, char *key, void *value, short mallocd, uint64_t i, uint64_t hash);
 static void* __hashmap_set(HashMap *h, char *key, void *value, short mallocd);
@@ -107,8 +107,7 @@ void* hashmap_remove(HashMap *h, char *key) {
 			free(h->nodes[i]);
 			h->nodes[i] = NULL;
 			h->used_nodes--;
-			// TODO: Refactor relayout nodes to allow for re-layout from a particular position (i)
-			__relayout_nodes(h);
+			__relayout_nodes(h, i);
 		}
 	}
 	return ret;
@@ -210,16 +209,19 @@ static int  __allocate_hashmap(HashMap *h, uint64_t num_els, HashFunction hash_f
 		int q = 0;
 		// TODO: The math to see if this ever needs to be done more than once
 		while (q == 0) {
-			q = __relayout_nodes(h);
+			q = __relayout_nodes(h, 0);
 		}
 	}
 	return HASHMAP_SUCCESS;
 }
 
-static int  __relayout_nodes(HashMap *h) {
+static int __relayout_nodes(HashMap *h, uint64_t loc) {
+	if (loc > h->number_nodes) {
+		loc = 0;
+	}
 	int moved_one = 1;
 	uint64_t i;
-	for (i = 0; i < h->number_nodes; i++) {
+	for (i = loc; i < h->number_nodes; i++) {
 		if(h->nodes[i] != NULL) {
 			uint64_t id;
 			int error;

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -3,7 +3,7 @@
 ***	 Author: Tyler Barrus
 ***	 email:  barrust@gmail.com
 ***
-***	 Version: 0.7.5
+***	 Version: 0.7.6
 ***	 Purpose: Simple, yet effective, hashmap implementation
 ***
 ***	 License: MIT 2015
@@ -21,10 +21,10 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#define HASHMAP_VERSION "0.7.5"
+#define HASHMAP_VERSION "0.7.6"
 #define HASHMAP_MAJOR 0
 #define HASHMAP_MINOR 7
-#define HASHMAP_REVISION 5
+#define HASHMAP_REVISION 6
 
 #define HASHMAP_FAILURE -1
 #define HASHMAP_SUCCESS 0
@@ -33,7 +33,7 @@
 #define hashmap_number_keys(h)   (h.used_nodes)
 
 
-typedef uint64_t (*HashFunction) (char *key);
+typedef uint64_t (*HashmapHashFunction) (char *key);
 
 /*******************************************************************************
 ***    Data structures
@@ -49,14 +49,14 @@ typedef struct hashmap {
 	hashmap_node **nodes;
 	uint64_t number_nodes;
 	uint64_t used_nodes;
-	HashFunction hash_function;
+	HashmapHashFunction hash_function;
 } HashMap;
 
 /* initialize the hashmap using the default hashing function */
 int hashmap_init(HashMap *h);
 
 /* initialize the hashmap using the provided hashing function */
-int hashmap_init_alt(HashMap *h, HashFunction hash_function);
+int hashmap_init_alt(HashMap *h, HashmapHashFunction hash_function);
 
 /*	frees all memory allocated by the hashmap library
 	NOTE: If the value is malloc'd memory, it is up to the user to free it */

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -53,69 +53,49 @@ typedef struct hashmap {
 } HashMap;
 
 /* initialize the hashmap using the default hashing function */
-#define hashmap_init(h) {hashmap_init_alt(h, NULL);}
+int hashmap_init(HashMap *h);
 
 /* initialize the hashmap using the provided hashing function */
 int hashmap_init_alt(HashMap *h, HashFunction hash_function);
 
-/*
-	frees all memory allocated by the hashmap library
-	NOTE: If the value is malloc'd memory, it is up to the user to free it
-*/
+/*	frees all memory allocated by the hashmap library
+	NOTE: If the value is malloc'd memory, it is up to the user to free it */
 void hashmap_destroy(HashMap *h);
 
-/*
-	Adds the key to the hashmap or updates the hashmap if it is already present
+/*	Adds the key to the hashmap or updates the hashmap if it is already present
 	If it updates instead of adds, returns the pointer to the replaced value,
 	(unless it is mallocd by the hashmap on insert) otherwise it returns the
-	pointer to the new value. Returns NULL if there is an error.
-*/
+	pointer to the new value. Returns NULL if there is an error. */
 void* hashmap_set(HashMap *h, char *key, void *value);
 
-/*
-	Adds the key to the hashmap or updates the key if already present. Also
+/*	Adds the key to the hashmap or updates the key if already present. Also
 	signals to the system to do a simple 'free' command on the value on
-	destruction.
-*/
+	destruction. */
 void* hashmap_set_alt(HashMap *h, char *key, void * value);
 
-/*
-	Returns the pointer to the value of the found key, or NULL if not found
-*/
+/* Returns the pointer to the value of the found key, or NULL if not found */
 void* hashmap_get(HashMap *h, char *key);
 
-/*
- 	Removes a key from the hashmap. NULL will be returned if it is not present.
+/*	Removes a key from the hashmap. NULL will be returned if it is not present.
 	If it is designated to be cleaned up, the memory will be free'd and NULL
 	returned. Otherwise, the pointer to the value will be returned.
 
-	TODO: Add a int flag to signal if NULL is b/c it was freed or not present
-*/
+	TODO: Add a int flag to signal if NULL is b/c it was freed or not present */
 void* hashmap_remove(HashMap *h, char *key);
 
-/*
-	Returns an array of all keys in the hashmap.
-	NOTE: It is up to the caller to free the array returned.
-
-	TODO: Sort keys?
-*/
+/*	Returns an array of all keys in the hashmap.
+	NOTE: It is up to the caller to free the array returned. */
 char** hashmap_keys(HashMap *h);
 
-/*
-	Prints out some basic stats about the hashmap
-*/
+/* Prints out some basic stats about the hashmap */
 void hashmap_stats(HashMap *h);
 
-/*
-	Easily add an int, this will malloc everything for the user and will signal
-	to de-allocate the memory on destruction
-*/
+/*	Easily add an int, this will malloc everything for the user and will signal
+	to de-allocate the memory on destruction */
 int* hashmap_set_int(HashMap *h, char *key, int value);
 
-/*
-	Easily add a string, this will malloc everything for the user and will signal
-	to de-allocate the memory on destruction
-*/
+/*	Easily add a string, this will malloc everything for the user and will signal
+	to de-allocate the memory on destruction */
 char* hashmap_set_string(HashMap *h, char *key, char *value);
 
 

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -94,6 +94,10 @@ void hashmap_stats(HashMap *h);
 	to de-allocate the memory on destruction */
 int* hashmap_set_int(HashMap *h, char *key, int value);
 
+/*	Easily add a float, this will malloc everything for the user and will signal
+	to de-allocate the memory on destruction */
+// char* hashmap_set_float(HashMap *h, char *key, float value);
+
 /*	Easily add a string, this will malloc everything for the user and will signal
 	to de-allocate the memory on destruction */
 char* hashmap_set_string(HashMap *h, char *key, char *value);


### PR DESCRIPTION
* Fix for possible race condition when **OpenMP** used
* Remove `#define` construct to allow functions to better be used directly in if-statements
* Start re-laying out nodes from removal location
* Unique HashFunction type when using with related libraries